### PR TITLE
Move obsolete appdata location of metainfo

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -19,7 +19,7 @@ appstream_file = i18n.merge_file(
   output: 'com.github.danielpinto8zz6.budgie-calendar-applet.appdata.xml',
   po_dir: '../po',
   install: true,
-  install_dir: join_paths(get_option('datadir'), 'appdata')
+  install_dir: join_paths(get_option('datadir'), 'metainfo')
 )
 
 appstream_util = find_program('appstream-util', required: false)


### PR DESCRIPTION
quick fix to place the appdata file into the recommended metainfo folder - appdata is obsolete